### PR TITLE
feat(extract): add support for translation property accessors

### DIFF
--- a/.changeset/gentle-deers-brake.md
+++ b/.changeset/gentle-deers-brake.md
@@ -1,0 +1,7 @@
+---
+"@labdigital/intl-extractor": minor
+---
+
+Support for translation property accessors
+
+Adds support for extracting labels from property accessors (e.g. `t.rich()` or `t.html()`).

--- a/src/extract.test.ts
+++ b/src/extract.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { extractLabels } from "./extract";
 
 describe("Test parseSource", () => {
-	test("should parse source", async () => {
+	test("should parse source", () => {
 		const source = `
 		"use client";
 
@@ -37,14 +37,14 @@ describe("Test parseSource", () => {
 		}
 		`;
 
-		const result = await extractLabels("MyComponent.tsx", source);
+		const result = extractLabels("MyComponent.tsx", source);
 		const expected = {
 			MyComponent: new Set(["foobar", "foodiebar", "title"]),
 		};
 		expect(result).toEqual(expected);
 	});
 
-	test("should parse source from server component using getTranslations", async () => {
+	test("should parse source from server component using getTranslations", () => {
 		const source = `
 		export const MyComponent = async () => {
 			const t = await getTranslations({ namespace: "ProductListing", locale });
@@ -63,10 +63,32 @@ describe("Test parseSource", () => {
 			)
 		`;
 
-		const result = await extractLabels("MyComponent.tsx", source);
+		const result = extractLabels("MyComponent.tsx", source);
 
 		const expected = {
 			ProductListing: new Set(["foobar", "title", "results"]),
+		};
+		expect(result).toEqual(expected);
+	});
+
+	test("should parse translator object functions", () => {
+		const source = `
+		export const MyComponent = () => {
+			const t = useTranslations("MyComponent");
+
+			const foobar = t.html("foobar");
+
+			return (
+				<div>
+					<h1>{t.rich("title")}</h1>
+				</div>
+			)
+		}
+		`;
+
+		const result = extractLabels("MyComponent.tsx", source);
+		const expected = {
+			MyComponent: new Set(["foobar", "title"]),
 		};
 		expect(result).toEqual(expected);
 	});

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,10 +1,6 @@
 import { promises as fsPromises } from "fs";
 import ts from "typescript";
-
-interface Scope {
-	variables: Map<string, string>;
-	parentScope: Scope | null;
-}
+import { createScope, type Scope } from "./scope";
 
 export async function extractLabelsFromFile(filePath: string) {
 	const fileContent = await fsPromises.readFile(filePath, "utf8");
@@ -135,28 +131,18 @@ export function extractLabels(filename: string, source: string) {
 	return result;
 }
 
-function createScope(parentScope: Scope | null = null): Scope {
-	return {
-		variables: new Map<string, string>(),
-		parentScope,
-	};
-}
-
-function findNamespaceForExpression(variableName: string, scope: Scope | null) {
-	while (scope !== null) {
+function findNamespaceForExpression(variableName: string, scope?: Scope) {
+	while (scope !== undefined) {
 		if (scope.variables.has(variableName)) {
 			return scope.variables.get(variableName);
 		}
 		scope = scope.parentScope;
 	}
-	return null;
+	return;
 }
 
-function findVariableInScopes(
-	variableName: string,
-	scope: Scope | null
-): boolean {
-	while (scope !== null) {
+function findVariableInScopes(variableName: string, scope?: Scope): boolean {
+	while (scope !== undefined) {
 		if (scope.variables.has(variableName)) {
 			return true;
 		}

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,0 +1,19 @@
+/**
+ * Individual scope used in a scope chain
+ */
+export interface Scope {
+	variables: Map<string, string>;
+	parentScope?: Scope;
+}
+
+/**
+ * Create a new scope
+ * @param parentScope the parent scope used in a scope chain
+ * @returns
+ */
+export function createScope(parentScope?: Scope): Scope {
+	return {
+		variables: new Map<string, string>(),
+		parentScope,
+	};
+}

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -9,7 +9,6 @@ export interface Scope {
 /**
  * Create a new scope
  * @param parentScope the parent scope used in a scope chain
- * @returns
  */
 export function createScope(parentScope?: Scope): Scope {
 	return {


### PR DESCRIPTION
The `t()` function also has properties for more advanced usage like rich text.
This commit adds support for checking the labels on these property accessors.

It also removes async statement from the extract function as it doesn't have any promises.
