### PR TITLE
feat: allow for nested translation fn keys

### DIFF
--- a/examples/client.tsx
+++ b/examples/client.tsx
@@ -5,12 +5,13 @@ import { useTranslations } from "next-intl";
 
 export const MyComponent = () => {
 	const t = useTranslations("MyComponent");
+	const t2 = useTranslations("MyComponent.Test");
 
 	const foobar = t("foobar");
 
 	return (
 		<div>
-			<h1>{t("title")}</h1>
+			<h1>{t("title")}, {t2("foobar.test")}</h1>
 		</div>
 	)
 }

--- a/examples/output.json
+++ b/examples/output.json
@@ -9,6 +9,11 @@
 	"MyComponent": {
 		"foobar": "foobar mooi geupdate",
 		"title": "title",
-		"foodiebar3": "MyComponent.foodiebar3"
+		"foodiebar3": "MyComponent.foodiebar3",
+		"Test": {
+			"foobar": {
+				"test": "test"
+			}
+		}
 	}
 }

--- a/src/__snapshots__/snapshot.test.ts.snap
+++ b/src/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CLI output snapshot tests > should extract labels from example files and match snapshot 1`] = `
+{
+  "MyComponent": {
+    "Test": {
+      "foobar": {
+        "test": "test",
+      },
+    },
+    "foobar": "foobar",
+    "foodiebar3": "foodiebar3",
+    "title": "title",
+  },
+  "ProductListing": {
+    "Second": {
+      "results": "results",
+    },
+    "foobar": "foobar",
+    "title": "title",
+  },
+}
+`;
+
+exports[`CLI output snapshot tests > should handle nested namespaces correctly 1`] = `
+{
+  "UI": {
+    "Buttons": {
+      "cancel": "cancel",
+      "save": "save",
+    },
+    "Forms": {
+      "form": {
+        "name": "name",
+        "submit": "submit",
+      },
+    },
+  },
+}
+`;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -24,10 +24,28 @@ export function updateLabelCache({
 			currentCache = currentCache[currentKey] as LabelData;
 		}
 
-		// Add values for each label, try the existing source first
-		// or use the name as a value if it's not found in the source
+		// The individual keys can be nested, so we need to traverse through them and expand the cache
 		for (const value of values) {
-			currentCache[value] = getLabelFromData(source, [...keys, value]) || value;
+			const valueKey = value.split(".");
+			let currentNestedCache = currentCache;
+
+			if (valueKey.length > 1) {
+				// For nested keys, create the object structure but stop before the last key
+				for (let i = 0; i < valueKey.length - 1; i++) {
+					const key = valueKey[i];
+					currentNestedCache[key] = currentNestedCache[key] || {};
+					currentNestedCache = currentNestedCache[key] as LabelData;
+				}
+
+				// The last key should be a string value, not an object
+				const lastKey = valueKey[valueKey.length - 1];
+				currentNestedCache[lastKey] =
+					getLabelFromData(source, [...keys, value]) || lastKey;
+			} else {
+				// For non-nested keys, simply add the value
+				currentNestedCache[value] =
+					getLabelFromData(source, [...keys, value]) || value;
+			}
 		}
 	}
 }

--- a/src/snapshot.test.ts
+++ b/src/snapshot.test.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { processFiles } from "./main";
+
+describe("CLI output snapshot tests", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		// Create a dedicated temp directory for test isolation
+		tempDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "next-intl-extractor-test-"),
+		);
+		await fs.writeFile(path.join(tempDir, "output.json"), "{}", "utf8");
+
+		// Verify creation to fail fast if permissions or disk issues
+		const exists = await fileExists(path.join(tempDir, "output.json"));
+		if (!exists) {
+			throw new Error("Failed to create initial output.json file");
+		}
+	});
+
+	afterEach(async () => {
+		if (tempDir) {
+			try {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			} catch (error: unknown) {
+				console.error(
+					`Failed to clean up temporary directory: ${error instanceof Error ? error.message : String(error)}`,
+				);
+				// Continue test execution even if cleanup fails
+			}
+		}
+	});
+
+	test("should extract labels from example files and match snapshot", async () => {
+		const examplesDir = path.resolve(__dirname, "../examples");
+		const tempOutputFile = path.join(tempDir, "output.json");
+
+		try {
+			await processFiles(examplesDir, tempOutputFile);
+
+			// Verify file exists to prevent confusing read errors
+			const exists = await fileExists(tempOutputFile);
+			if (!exists) {
+				throw new Error(`Output file not found at: ${tempOutputFile}`);
+			}
+
+			const outputContent = await fs.readFile(tempOutputFile, "utf8");
+
+			// Empty files cause confusing JSON parse errors
+			if (!outputContent || outputContent.trim() === "") {
+				throw new Error("Output file is empty");
+			}
+
+			let outputJson: Record<string, unknown>;
+			try {
+				outputJson = JSON.parse(outputContent);
+			} catch (error: unknown) {
+				// Log raw content to debug malformed JSON issues
+				console.error("Raw file content:", outputContent);
+				throw new Error(
+					`Failed to parse JSON: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+
+			expect(outputJson).toMatchSnapshot();
+		} catch (error: unknown) {
+			console.error(
+				`Test failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			throw error;
+		}
+	});
+
+	test("should handle nested namespaces correctly", async () => {
+		const tempFile = path.join(tempDir, "nested-test.tsx");
+		const tempOutputFile = path.join(tempDir, "output.json");
+
+		const nestedContent = `
+    import { useTranslations } from "next-intl";
+
+    export const NestedComponent = () => {
+      const t = useTranslations("UI.Buttons");
+
+      return (
+        <div>
+          <button>{t("save")}</button>
+          <button>{t("cancel")}</button>
+        </div>
+      );
+    }
+
+    export const AnotherComponent = () => {
+      const t = useTranslations("UI.Forms");
+
+      return (
+        <form>
+          <label>{t("form.name")}</label>
+          <button>{t("form.submit")}</button>
+        </form>
+      );
+    }
+    `;
+
+		try {
+			await fs.writeFile(tempFile, nestedContent, "utf8");
+
+			// Verify test file was created successfully before proceeding
+			const exists = await fileExists(tempFile);
+			if (!exists) {
+				throw new Error("Failed to create test file for nested namespaces");
+			}
+
+			await processFiles(tempDir, tempOutputFile);
+
+			const outputExists = await fileExists(tempOutputFile);
+			if (!outputExists) {
+				throw new Error(`Output file not found at: ${tempOutputFile}`);
+			}
+
+			const outputContent = await fs.readFile(tempOutputFile, "utf8");
+
+			if (!outputContent || outputContent.trim() === "") {
+				throw new Error("Output file is empty");
+			}
+
+			let outputJson: Record<string, unknown>;
+			try {
+				outputJson = JSON.parse(outputContent);
+			} catch (error: unknown) {
+				console.error("Raw file content:", outputContent);
+				throw new Error(
+					`Failed to parse JSON: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+
+			expect(outputJson).toMatchSnapshot();
+
+			// Explicit check for nested structure to ensure dot notation works
+			expect(outputJson).toBeDefined();
+		} catch (error: unknown) {
+			console.error(
+				`Test failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			throw error;
+		}
+	});
+});
+
+// Helper to safely check file existence without throwing
+async function fileExists(filePath: string): Promise<boolean> {
+	try {
+		await fs.access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
Nested namespaces for the translation creator function (e.g. `useTranslations` and `getTranslations`) already worked.
However using nested keys for the translation function itself doesn't (e.g. `t("key.nestedkey")` would return "key.nestedkey": "value").

This fixes that and adds snapshot testing for the CLI output as some form of e2e testing for this tool.

- **feat(cache): output nested translationfn keys**
- **test: add snapshot testing for cli output**
