### PR TITLE
feat: allow undefined namespace

### DIFF
--- a/.changeset/proud-clubs-wear.md
+++ b/.changeset/proud-clubs-wear.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/intl-extractor": minor
+---
+
+Allow useTransltions and getTranslations usage without passing a namespace

--- a/src/extract.test.ts
+++ b/src/extract.test.ts
@@ -65,6 +65,28 @@ describe("Test parseSource", () => {
 		};
 		expect(result).toEqual(expected);
 	});
+
+	test("should not throw when useTranslations is called without a namespace", () => {
+		const source = `
+			export const MyComponent = () => {
+				const t = useTranslations();
+
+				return <h1>{t('title')}</h1>;
+			}
+		`;
+		expect(() => extractLabels("MyComponent.tsx", source)).not.toThrow();
+	});
+
+	test("should not throw when getTranslations is called without a namespace", () => {
+		const source = `
+			export const MyComponent = async () => {
+				const t = await getTranslations();
+
+				return <h1>{t('title')}</h1>;
+			}
+		`;
+		expect(() => extractLabels("MyComponent.tsx", source)).not.toThrow();
+	});
 });
 
 describe("getTranslator usage", () => {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -40,12 +40,12 @@ export function extractLabels(filename: string, source: string) {
 				callExpr.expression.text === "useTranslations"
 			) {
 				if (node.name && ts.isIdentifier(node.name)) {
+					const namespaceArg = callExpr.arguments.at(0);
 					currentScope.variables.set(
 						node.name.text,
-						// Remove the surrounding quotes
-						callExpr.arguments[0]
-							.getText()
-							.slice(1, -1),
+						// Remove the surrounding quotes. When called without
+						// a namespace (e.g. userTranslations()), default to the root scope.
+						namespaceArg ? namespaceArg.getText().slice(1, -1) : "",
 					);
 				}
 			}
@@ -66,10 +66,13 @@ export function extractLabels(filename: string, source: string) {
 				callExpr.expression.text === "getTranslations"
 			) {
 				if (node.name && ts.isIdentifier(node.name)) {
-					const arg = callExpr.arguments[0];
+					const arg = callExpr.arguments.at(0);
 
-					// If the argument is an object, parse the object
-					if (ts.isObjectLiteralExpression(arg)) {
+					// Called without an argument (e.g. getTranslations()) -> root scope
+					if (!arg) {
+						currentScope.variables.set(node.name.text, "");
+					} else if (ts.isObjectLiteralExpression(arg)) {
+						// If the argument is an object, parse the object
 						// Iterate over the object properties
 						for (const prop of arg.properties) {
 							if (
@@ -90,7 +93,7 @@ export function extractLabels(filename: string, source: string) {
 						currentScope.variables.set(
 							node.name.text,
 							// Remove the surrounding quotes
-							callExpr.arguments[0]
+							arg
 								.getText()
 								.slice(1, -1),
 						);


### PR DESCRIPTION
Currently the extractor throws an error when no namespace has been provided in `useTranslations` or `getTranslations`. This PR allows an undefined namespace by defaulting to the root scope when no namespace is given.