### PR TITLE
fix: use @typescript/typescript6 for AST parsing

### DIFF
--- a/.changeset/typescript-7-compat.md
+++ b/.changeset/typescript-7-compat.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/intl-extractor": minor
+---
+
+Use the `@typescript/typescript6` compatibility package for AST parsing instead of the consumer's `typescript` peer dependency. TypeScript 7.0 ships without the classic JavaScript API (`ts.createSourceFile`, `ts.ScriptTarget`, the `is*` node guards), so extraction broke when consumers upgraded. Bundling the stable TS 6.0 API decouples the extractor from the consumer's compiler version and drops the `typescript` peer dependency.

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
 	},
 	"dependencies": {
 		"@biomejs/biome": "^2.0.0",
+		"@typescript/typescript6": "6.0.2",
 		"glob": "11.1.0",
 		"yargs": "^18.0.0"
 	},
 	"peerDependencies": {
-		"@parcel/watcher": "2.5.1",
-		"typescript": ">=5.5"
+		"@parcel/watcher": "2.5.1"
 	},
 	"peerDependenciesMeta": {
 		"@parcel/watcher": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.0.0
         version: 2.0.0
+      '@typescript/typescript6':
+        specifier: 6.0.2
+        version: 6.0.2
       glob:
         specifier: 11.1.0
         version: 11.1.0
@@ -770,6 +773,10 @@ packages:
 
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@vitest/coverage-v8@3.2.6':
     resolution: {integrity: sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==}
@@ -1556,6 +1563,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   unconfig@7.3.2:
     resolution: {integrity: sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==}
 
@@ -2288,6 +2300,10 @@ snapshots:
   '@types/yargs@17.0.33':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@24.0.3)(jiti@2.4.2)(yaml@2.7.0))':
     dependencies:
@@ -3045,6 +3061,8 @@ snapshots:
     optional: true
 
   typescript@5.8.3: {}
+
+  typescript@6.0.3: {}
 
   unconfig@7.3.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 minimumReleaseAge: 20160
+minimumReleaseAgeExclude:
+  - "@typescript/typescript6"
 trustPolicy: no-downgrade
 onlyBuiltDependencies:
   - '@biomejs/biome'

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,5 +1,5 @@
 import { promises as fsPromises } from "node:fs";
-import ts from "typescript";
+import ts from "@typescript/typescript6";
 import { createScope, type Scope } from "./scope";
 
 export async function extractLabelsFromFile(filePath: string) {


### PR DESCRIPTION
TypeScript 7.0 ships without the classic JavaScript compiler API, so
`ts.createSourceFile` / `ts.ScriptTarget` / the `is*` node guards are no
longer available when a consumer resolves the `typescript` peer to 7.x.
This broke extraction with "Cannot read properties of undefined (reading
'Latest')".

Depend on the `@typescript/typescript6` compat package (bundling the
stable TS 6.0 API) instead of the consumer's typescript peer. This
decouples the extractor from the consumer's compiler version and drops
the typescript peer dependency.
